### PR TITLE
Fix to compath.py and update to para dbn_alert

### DIFF
--- a/para_dbn/bin/dbn_alert
+++ b/para_dbn/bin/dbn_alert
@@ -45,7 +45,12 @@ else
       exit
    fi
    echo "PARA dbn_alert out:  ${NEW_TYPE:-$1} ${NEW_SUBTYPE:-$2} $3 $4"
-   export SIPHONROOT=/lfs/h1/ops/prod/dbnet_siphon
+   whoami=$(whoami)
+   if [ $whoami == ops.para ]; then
+     export SIPHONROOT=/lfs/h1/ops/para/dbnet_siphon
+   elif [ $whoami == ops.prod ]; then
+     export SIPHONROOT=/lfs/h1/ops/prod/dbnet_siphon
+   fi
    export DBNROOT=$SIPHONROOT
    $SIPHONROOT/bin/dbn_alert ${NEW_TYPE:-$1} ${NEW_SUBTYPE:-$2} $3 $4
 

--- a/ush/compath.py
+++ b/ush/compath.py
@@ -112,7 +112,7 @@ def get_compath(relpath, envir=None, out=False, verbose=False):
                     production COM directory.
     """
 
-    relpath = re.sub("(/v\d+\.\d+)[\d\.]*",r"\1",relpath) # chop version number down to first 2 digits
+    relpath = re.sub(r"(/v\d+\.\d+)[\d\.]*",r"\1",relpath) # chop version number down to first 2 digits
 
     match_result = re.match(r'(?P<envir>prod|para|test|canned)?/?(?:com/)?(?P<NET>[\w-]+)/(?P<version>v\d+\.\d+[^/]*)((?:/(?P<RUN>[\w-]+?)(?:\.(?P<PDY>2\d(?:\d\d){1,4}))?)?(?P<tail>/.+)?)?$', relpath)
     if match_result:


### PR DESCRIPTION
This PR closes the following issues
- [x] #1 

This PR contains the following changes

**Bug Fixes**
- `ush/compath.py` - Use raw string in regex to resolve [SyntaxWarning in python 3.12](https://docs.python.org/3.12/whatsnew/3.12.html#other-language-changes)

**Enhancements**
- `para_dbn/bin/dbn_alert` - Set `SIPHONROOT` dependent on executing ops user (@XiaoxueWang-NCO). This change must be implemented in tandem with corresponding changes to ecflow, which is currently v5.6.0.15 in para