### PR TITLE
Use raw string in regex expression in compath.py

### DIFF
--- a/ush/compath.py
+++ b/ush/compath.py
@@ -112,7 +112,7 @@ def get_compath(relpath, envir=None, out=False, verbose=False):
                     production COM directory.
     """
 
-    relpath = re.sub("(/v\d+\.\d+)[\d\.]*",r"\1",relpath) # chop version number down to first 2 digits
+    relpath = re.sub(r"(/v\d+\.\d+)[\d\.]*",r"\1",relpath) # chop version number down to first 2 digits
 
     match_result = re.match(r'(?P<envir>prod|para|test|canned)?/?(?:com/)?(?P<NET>[\w-]+)/(?P<version>v\d+\.\d+[^/]*)((?:/(?P<RUN>[\w-]+?)(?:\.(?P<PDY>2\d(?:\d\d){1,4}))?)?(?P<tail>/.+)?)?$', relpath)
     if match_result:


### PR DESCRIPTION
- [x] Closes #1 

This PR contains the following changes

**Bug Fixes**
- `ush/compath.py` - Use raw string in regex to resolve [SyntaxWarning in python 3.12](https://docs.python.org/3.12/whatsnew/3.12.html#other-language-changes)

**Testing**
- This bug fix has been running in para for months now. It has been verified that `SyntaxWarning` is no longer thrown by `compath.py`.
- Example outputs on Dogwood:
  - Prod: `/lfs/h1/ops/prod/output/20251029/aigfs_prep_00.o75691783`
  - Para: `/lfs/h1/ops/para/output/20251029/aigfs_prep_00.o75691844`