### PR TITLE
Set SIPHONROOT based on ops user

### DIFF
--- a/para_dbn/bin/dbn_alert
+++ b/para_dbn/bin/dbn_alert
@@ -45,7 +45,12 @@ else
       exit
    fi
    echo "PARA dbn_alert out:  ${NEW_TYPE:-$1} ${NEW_SUBTYPE:-$2} $3 $4"
-   export SIPHONROOT=/lfs/h1/ops/prod/dbnet_siphon
+   whoami=$(whoami)
+   if [ $whoami == ops.para ]; then
+     export SIPHONROOT=/lfs/h1/ops/para/dbnet_siphon
+   elif [ $whoami == ops.prod ]; then
+     export SIPHONROOT=/lfs/h1/ops/prod/dbnet_siphon
+   fi
    export DBNROOT=$SIPHONROOT
    $SIPHONROOT/bin/dbn_alert ${NEW_TYPE:-$1} ${NEW_SUBTYPE:-$2} $3 $4
 


### PR DESCRIPTION
This PR makes the following changes:

**Enhancements**

`para_dbn/bin/dbn_alert` - Set SIPHONROOT dependent on executing ops user (@XiaoxueWang-NCO). This change must be implemented in tandem with corresponding changes to ecflow, which is currently v5.6.0.15 in para

This change is dependent on corresponding changes in https://github.com/NCO-HPC/ecflow v5.6.0.15 (coming soon).