### PR TITLE
Decide how to kill job based on ecflow/scheduler

### DIFF
--- a/ush/err_exit
+++ b/ush/err_exit
@@ -51,15 +51,22 @@ elif [ -s errfile ]; then
   >&2 cat errfile
 fi
 
-# Write to ecflow log:
+# Write to ecflow log w/ ecflow_client:
 if [ "$SENDECF" = "YES" ]; then
+ echo "Killing the job via ecflow comands"
   timeout 30 ecflow_client --msg "$ECF_NAME: $msg1"
   timeout 30 ssh $ECF_HOST "echo \"$msg2\" >> ${ECF_JOBOUT:?}"
-fi
-
-# KILL THE JOB:
-if [ -z $PBS_JOBID ]; then
-ecflow_client --kill=${ECF_NAME:?}
+  timeout 30 ecflow_client --kill=${ECF_NAME:?} && sleep 10
+# Kill job directly if not using ecflow
+elif [ -n "$PBS_JOBID" ]; then
+  echo "Killing the job via qdel"
+  qdel $PBS_JOBID
+elif [ -n "$SLURM_JOBID" ]; then
+  echo "Killing the job via scancel"
+  scancel "$SLURM_JOBID"
+elif [ -n "$LSF_JOBID" ]; then
+  echo "Killing the job via bkill"
+  bkill "$LSF_JOBID"
 else
-qdel $PBS_JOBID
+  exit "${err:-1}"
 fi

--- a/ush/err_exit
+++ b/ush/err_exit
@@ -53,12 +53,12 @@ fi
 
 # Write to ecflow log w/ ecflow_client:
 if [ "$SENDECF" = "YES" ]; then
- echo "Killing the job via ecflow comands"
   timeout 30 ecflow_client --msg "$ECF_NAME: $msg1"
   timeout 30 ssh $ECF_HOST "echo \"$msg2\" >> ${ECF_JOBOUT:?}"
-  timeout 30 ecflow_client --kill=${ECF_NAME:?} && sleep 10
-# Kill job directly if not using ecflow
-elif [ -n "$PBS_JOBID" ]; then
+fi
+
+# Kill job via scheduler
+if [ -n "$PBS_JOBID" ]; then
   echo "Killing the job via qdel"
   qdel $PBS_JOBID
 elif [ -n "$SLURM_JOBID" ]; then
@@ -67,6 +67,8 @@ elif [ -n "$SLURM_JOBID" ]; then
 elif [ -n "$LSF_JOBID" ]; then
   echo "Killing the job via bkill"
   bkill "$LSF_JOBID"
-else
-  exit "${err:-1}"
+# Kill ecFlow tasks that did not submit to a scheduler
+elif  [ "$SENDECF" = "YES" ]; then
+  echo "Killing the job via ecflow kill"
+  ecflow_client --kill=${ECF_NAME:?}
 fi


### PR DESCRIPTION
This PR changes how `err_exit` kills the current job.

- ~If ecflow is being used, the `--kill` command is used (no change) and then *the script sleeps to wait for `killecfjob` to kill the job via PBS* as expected.~
- The scheduler is identified based on environment variables used for job IDs by PBS, SLURM, and LSF. This provides flexibility to developers working on different systems.
- `ecflow_client --kill` is called only if a job scheduler was not identified

I received a lot of guidance from @DianeStokes-NCO on this one, thank you.

Associated bugzilla: [Production Utilities 1384](http://www2.spa.ncep.noaa.gov/bugzilla/show_bug.cgi?id=1384)

**Testing**
- Started testing in para 2025/11/05 ~1523Z