### PR TITLE
Add check for 0-byte files to cpreq

### DIFF
--- a/tests/patch/err_chk
+++ b/tests/patch/err_chk
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Patched version of err_chk only for testing
+# 
+
+if [[ $err -ne 0 ]]; then
+    err_exit "$1"
+fi

--- a/tests/patch/err_exit
+++ b/tests/patch/err_exit
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "FATAL ERROR: return code $err" >&2
+echo "FATAL ERROR: $1" >&2
+exit $err

--- a/tests/patch/err_exit
+++ b/tests/patch/err_exit
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 echo "FATAL ERROR: return code $err" >&2
-echo "FATAL ERROR: $1" >&2
+echo "FATAL ERROR: $msg" >&2
 exit $err

--- a/tests/test_cpreq.sh
+++ b/tests/test_cpreq.sh
@@ -84,7 +84,7 @@ test_one_file() {
 }
 
 
-test_one_empty_file_no_flag() {
+test_one_empty_file_no_opt() {
     # -------------------------------------------------------
     # Test that cpreq *fails* to copy a single zero size file
     # without the specified '-z' option
@@ -108,7 +108,7 @@ test_one_empty_file_no_flag() {
 }
 
 
-test_one_empty_file_flag() {
+test_one_empty_file_opt() {
     # ------------------------------------------------------
     # Test that cpreq copys a single zero size file with the
     # '-z' option specified
@@ -150,7 +150,7 @@ test_multiple_files() {
 }
 
 
-test_multiple_empty_files_no_flag() {
+test_multiple_empty_files_no_opt() {
     # -----------------------------------------------------
     # Test that cpreq *fails* to copy multiple files if one
     # or more are size zero and the '-z' is not specified
@@ -177,7 +177,7 @@ test_multiple_empty_files_no_flag() {
 }
 
 
-test_multiple_empty_files_flag() {
+test_multiple_empty_files_opt() {
     # ---------------------------------------------------
     # Test the cpreq copies multiple zero size files with
     # the '-z' option specified
@@ -200,7 +200,7 @@ test_multiple_empty_files_flag() {
 }
 
 
-test_mixed_files_no_flag() {
+test_mixed_files_no_opt() {
     # ---------------------------------------------------
     # Test that cpreq *fails* to copy multiple files when
     # one or more are size zero and '-z' is not specified
@@ -226,7 +226,7 @@ test_mixed_files_no_flag() {
 }
 
 
-test_mixed_files_flag() {
+test_mixed_files_opt() {
     # -------------------------------------------------
     # Test that cpreq copies multiple files when one or
     # more are size zero and '-z' is specified
@@ -248,10 +248,50 @@ test_mixed_files_flag() {
 }
 
 
-test_with_cp_flags() {
-    # ------------------------------------
-    # Test that cpreq accepts cp arguments
-    # ------------------------------------
+test_one_cp_opt() {
+    # ----------------------------
+    # Test with a single cp option
+    # ----------------------------
+    test_dir=${TMP_DIR}/${FUNCNAME}
+    setup "${test_dir}"
+
+    export pgm=${FUNCNAME}
+
+    echo "This is a file with text in it" > ${test_dir}/source_dir/file1.txt
+
+    $TARGET_SCRIPT -p ${test_dir}/source_dir/file1.txt ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
+
+    err_msg=$( grep "FATAL ERROR" ${test_dir}/${FUNCNAME}.err )
+
+    test -z "$err_msg"
+    check_results ${FUNCNAME} $? "$err_msg"
+}
+
+
+test_one_cp_opt_zero_byte() {
+    # -----------------------------------
+    # Test with -z and a single cp option
+    # -----------------------------------
+    test_dir=${TMP_DIR}/${FUNCNAME}
+    setup "${test_dir}"
+
+    export pgm=${FUNCNAME}
+
+    touch ${test_dir}/source_dir/file1.txt
+
+    $TARGET_SCRIPT -z -p ${test_dir}/source_dir/file1.txt ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
+
+    err_msg=$( grep "FATAL ERROR" ${test_dir}/${FUNCNAME}.err )
+
+    test -z "$err_msg"
+    check_results ${FUNCNAME} $? "$err_msg"
+}
+
+
+test_multiple_cp_opts() {
+    # ---------------------------------------------
+    # Test that cpreq accepts multiple cp arguments
+    # ---------------------------------------------
     test_dir=${TMP_DIR}/${FUNCNAME}
     setup "${test_dir}"
 
@@ -259,7 +299,7 @@ test_with_cp_flags() {
 
     echo "This is a file with text in it" > ${test_dir}/source_dir/file1.txt
     
-    $TARGET_SCRIPT -z -pi ${test_dir}/source_dir/file* ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
+    $TARGET_SCRIPT -z -pr ${test_dir}/source_dir/file* ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
 
     err_msg=$( egrep "FATAL ERROR|illegal" ${test_dir}/${FUNCNAME}.err )
 
@@ -267,10 +307,28 @@ test_with_cp_flags() {
     check_results ${FUNCNAME} $? "$err_msg"
 }
 
-test_with_cp_target_dir() {
-    # -----------------
-    # Test with -t flag
-    # -----------------
+
+test_multiple_cp_opts_zero_byte() {
+    # --------------------------------------
+    # Test with '-z' and multiple cp options
+    # --------------------------------------
+    test_dir=${TMP_DIR}/${FUNCNAME}
+    setup "${test_dir}"
+
+    export pgm=${FUNCNAME}
+
+    touch ${test_dir}/source_dir/file1.txt ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
+
+    err_msg=$( grep "FATAL ERROR" ${test_dir}/${FUNCNAME}.err )
+
+    test -z "$err_msg"
+    check_results ${FUNCNAME} $? "$err_msg"
+}
+
+test_cp_opt_t() {
+    # ----------------------
+    # Test with cp -t option
+    # ----------------------
     test_dir=${TMP_DIR}/${FUNCNAME}
     setup "${test_dir}"
 
@@ -282,13 +340,10 @@ test_with_cp_target_dir() {
 
     err_msg=$( grep "FATAL ERROR" ${test_dir}/${FUNCNAME}.err )
 
-    test -z "$err_msg"
+    test -z "$err_msg" -a -s ${test_dir}/target_dir/file1.txt
     check_results ${FUNCNAME} $? "$err_msg"
 }
 
-test_with_cp_no_target_dir() {
-    check_results ${FUNCNAME} 1 "Test not implemented"
-}
 
 # -----------
 # Main script
@@ -311,16 +366,18 @@ main() {
     echo "$( basename "$0" )"
     echo "====================================="
     wrapper "test_one_file"
-    wrapper "test_one_empty_file_no_flag"
-    wrapper "test_one_empty_file_flag"
+    wrapper "test_one_empty_file_no_opt"
+    wrapper "test_one_empty_file_opt"
     wrapper "test_multiple_files"
-    wrapper "test_multiple_empty_files_no_flag"
-    wrapper "test_multiple_empty_files_flag"
-    wrapper "test_mixed_files_no_flag"
-    wrapper "test_mixed_files_flag"
-    wrapper "test_with_cp_flags"
-    wrapper "test_with_cp_target_dir"
-    wrapper "test_with_cp_no_target_dir"
+    wrapper "test_multiple_empty_files_no_opt"
+    wrapper "test_multiple_empty_files_opt"
+    wrapper "test_mixed_files_no_opt"
+    wrapper "test_mixed_files_opt"
+    wrapper "test_one_cp_opt"
+    wrapper "test_one_cp_opt_zero_byte"
+    wrapper "test_multiple_cp_opts"
+    wrapper "test_multiple_cp_opts_zero_byte"
+    wrapper "test_cp_opt_t"
     echo "====================================="
 
     echo "Summary"

--- a/tests/test_cpreq.sh
+++ b/tests/test_cpreq.sh
@@ -1,0 +1,331 @@
+#!/bin/bash
+# =======================
+# test_cpreq.sh
+# -------------
+# Purpose: test ush/cpreq
+#
+# Arguments: None
+# =======================
+
+# -----------------
+# Utility functions
+# -----------------
+
+setup() {
+    test_dir=$1
+    source_dir=${test_dir}/source_dir
+    target_dir=${test_dir}/target_dir
+    mkdir -p ${source_dir}
+    mkdir -p ${target_dir}
+}
+
+teardown() {
+    echo "${FUNCNAME} not implemented"
+    #cd ${TMP_DIR}
+    #rm -rf ${TMP_DIR}/*
+    #cd ${TMP_DIR}/..
+    #rmdir ${TMP_DIR}
+}
+
+wrapper() {
+    func=$1
+    echo "----------------------------"
+
+    ${func}
+
+    echo "----------------------------"
+    echo ""
+}
+
+check_results() {
+    func_name=$1
+    err=$2
+    err_msg=$3
+
+    if [[ $err -eq 0 ]]; then
+        echo "PASSED: ${func_name}"
+        export NPASSED=$(( NPASSED + 1 ))
+    else
+        echo "FAILED: ${func_name}"
+        echo "$err_msg"
+        export NFAILED=$(( NFAILED + 1))
+    fi
+}
+
+err_chk() {
+    /lfs/h1/nco/idsb/noscrub/russell.manser/git_repos/prod_util/tests/patch/err_chk "$*"
+}
+
+err_exit() {
+    /lfs/h1/nco/idsb/noscrub/russell.manser/git_repos/prod_util/tests/patch/err_exit
+}
+
+# ----------
+# Test suite
+# ----------
+
+
+test_one_file() {
+    # Test that cpreq copies a single nonzero size file
+    # -------------------------------------------------
+    test_dir=${TMP_DIR}/${FUNCNAME}
+    setup "${test_dir}"
+
+    export pgm=${FUNCNAME}
+
+    echo "This is a file with text in it" > ${test_dir}/source_dir/file.txt
+
+    $TARGET_SCRIPT ${test_dir}/source_dir/file.txt ${test_dir}/target_dir/ 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
+
+    err_msg=$( grep "FATAL ERROR" ${test_dir}/${FUNCNAME}.err )
+
+    test -z "$err_msg"
+    check_results ${FUNCNAME} $? "$err_msg"
+}
+
+
+test_one_empty_file_no_flag() {
+    # -------------------------------------------------------
+    # Test that cpreq *fails* to copy a single zero size file
+    # without the specified '-z' option
+    #
+    # This test will pass upon *any* failure.
+    #
+    # TODO: pass only on specific failure.
+    # -------------------------------------------------------
+    test_dir=${TMP_DIR}/${FUNCNAME}
+    setup "${test_dir}"
+
+    export pgm=${FUNCNAME}
+
+    touch ${test_dir}/source_dir/file.txt
+    $TARGET_SCRIPT ${test_dir}/source_dir/file.txt ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
+
+    err_msg=$( grep "FATAL ERROR" ${test_dir}/${FUNCNAME}.err )
+
+    test ! -z "$err_msg"
+    check_results ${FUNCNAME} $? "$err_msg"
+}
+
+
+test_one_empty_file_flag() {
+    # ------------------------------------------------------
+    # Test that cpreq copys a single zero size file with the
+    # '-z' option specified
+    # ------------------------------------------------------
+    test_dir=${TMP_DIR}/${FUNCNAME}
+    setup "${test_dir}"
+
+    export pgm=${FUNCNAME}
+
+    touch ${test_dir}/source_dir/file.txt
+    $TARGET_SCRIPT -z ${test_dir}/source_dir/file.txt ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
+
+    err_msg=$( grep "FATAL ERROR" ${test_dir}/${FUNCNAME}.err )
+
+    test -z "$err_msg"
+    check_results ${FUNCNAME} $? "$err_msg"
+}
+
+
+test_multiple_files() {
+    # --------------------------------------------------
+    # Test that cpreq copies multiple nonzero size files
+    # --------------------------------------------------
+    test_dir=${TMP_DIR}/${FUNCNAME}
+    setup "${test_dir}"
+
+    export pgm=${FUNCNAME}
+
+    for i in $( seq 1 3 ); do
+        echo "This is file $i with text in it" > ${test_dir}/source_dir/file${i}.txt
+    done
+
+    $TARGET_SCRIPT ${test_dir}/source_dir/file* ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
+
+    err_msg=$( grep "FATAL ERROR" ${test_dir}/${FUNCNAME}.err )
+
+    test -z "$err_msg"
+    check_results ${FUNCNAME} $? "$err_msg"
+}
+
+
+test_multiple_empty_files_no_flag() {
+    # -----------------------------------------------------
+    # Test that cpreq *fails* to copy multiple files if one
+    # or more are size zero and the '-z' is not specified
+    #
+    # This test will pass upon *any* failure.
+    #
+    # TODO: pass only on specific failure.
+    # -----------------------------------------------------
+    test_dir=${TMP_DIR}/${FUNCNAME}
+    setup "${test_dir}"
+
+    export pgm=${FUNCNAME}
+
+    for i in $( seq 1 3 ); do
+        touch ${test_dir}/source_dir/file${i}.txt
+    done
+
+    $TARGET_SCRIPT ${test_dir}/source_dir/file* ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
+
+    err_msg=$( grep "FATAL ERROR" ${test_dir}/${FUNCNAME}.err )
+
+    test ! -z "$err_msg"
+    check_results ${FUNCNAME} $? "$err_msg"
+}
+
+
+test_multiple_empty_files_flag() {
+    # ---------------------------------------------------
+    # Test the cpreq copies multiple zero size files with
+    # the '-z' option specified
+    # ---------------------------------------------------
+    test_dir=${TMP_DIR}/${FUNCNAME}
+    setup "${test_dir}"
+
+    export pgm=${FUNCNAME}
+
+    for i in $( seq 1 3 ); do
+        touch ${test_dir}/source_dir/file${i}.txt
+    done
+
+    $TARGET_SCRIPT -z ${test_dir}/source_dir/file* ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
+
+    err_msg=$( grep "FATAL ERROR" ${test_dir}/${FUNCNAME}.err )
+
+    test -z "$err_msg"
+    check_results ${FUNCNAME} $? "$err_msg"
+}
+
+
+test_mixed_files_no_flag() {
+    # ---------------------------------------------------
+    # Test that cpreq *fails* to copy multiple files when
+    # one or more are size zero and '-z' is not specified
+    #
+    # This test will pass upon *any* failure.
+    #
+    # TODO: pass only on specific failure.
+    # ---------------------------------------------------
+    test_dir=${TMP_DIR}/${FUNCNAME}
+    setup "${test_dir}"
+
+    export pgm=${FUNCNAME}
+
+    echo "This is a file with text in it" > ${test_dir}/source_dir/file1.txt
+    touch ${test_dir}/source_dir/file2.txt
+
+    $TARGET_SCRIPT ${test_dir}/source_dir/file* ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
+
+    err_msg=$( grep "FATAL ERROR" ${test_dir}/${FUNCNAME}.err )
+
+    test ! -z "$err_msg"
+    check_results ${FUNCNAME} $? "$err_msg"
+}
+
+
+test_mixed_files_flag() {
+    # -------------------------------------------------
+    # Test that cpreq copies multiple files when one or
+    # more are size zero and '-z' is specified
+    # -------------------------------------------------
+    test_dir=${TMP_DIR}/${FUNCNAME}
+    setup "${test_dir}"
+
+    export pgm=${FUNCNAME}
+
+    echo "This is a file with text in it" > ${test_dir}/source_dir/file1.txt
+    touch ${test_dir}/source_dir/file2.txt
+
+    $TARGET_SCRIPT -z ${test_dir}/source_dir/file* ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
+    
+    err_msg=$( grep "FATAL ERROR" ${test_dir}/${FUNCNAME}.err )
+
+    test -z "$err_msg"
+    check_results ${FUNCNAME} $? "$err_msg"
+}
+
+
+test_with_cp_flags() {
+    # ------------------------------------
+    # Test that cpreq accepts cp arguments
+    # ------------------------------------
+    test_dir=${TMP_DIR}/${FUNCNAME}
+    setup "${test_dir}"
+
+    export pgm=${FUNCNAME}
+
+    echo "This is a file with text in it" > ${test_dir}/source_dir/file1.txt
+    
+    $TARGET_SCRIPT -z -pi ${test_dir}/source_dir/file* ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
+
+    err_msg=$( egrep "FATAL ERROR|illegal" ${test_dir}/${FUNCNAME}.err )
+
+    test -z "$err_msg"
+    check_results ${FUNCNAME} $? "$err_msg"
+}
+
+test_with_cp_target_dir() {
+    # -----------------
+    # Test with -t flag
+    # -----------------
+    test_dir=${TMP_DIR}/${FUNCNAME}
+    setup "${test_dir}"
+
+    export pgm=${FUNCNAME}
+
+    echo "This is a file with text in it" > ${test_dir}/source_dir/file1.txt
+
+    $TARGET_SCRIPT -t ${test_dir}/target_dir ${test_dir}/source_dir/file1.txt 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
+
+    err_msg=$( grep "FATAL ERROR" ${test_dir}/${FUNCNAME}.err )
+
+    test -z "$err_msg"
+    check_results ${FUNCNAME} $? "$err_msg"
+}
+
+test_with_cp_no_target_dir() {
+    check_results ${FUNCNAME} 1 "Test not implemented"
+}
+
+# -----------
+# Main script
+# -----------
+
+main() {
+    export -f err_chk
+    export -f err_exit
+
+    TMP_ROOT="/lfs/h1/nco/stmp/russell.manser"
+    export TMP_DIR="${TMP_ROOT}/test_cpreq_$(date +%Y%m%d_%H%M_%N)"
+    echo "Test directory: ${TMP_DIR}"
+
+    PKG_ROOT="/lfs/h1/nco/idsb/noscrub/russell.manser/git_repos/prod_util"
+    export TARGET_SCRIPT=${PKG_ROOT}/ush/cpreq
+
+    export NPASSED=0
+    export NFAILED=0
+
+    echo "$( basename "$0" )"
+    echo "====================================="
+    wrapper "test_one_file"
+    wrapper "test_one_empty_file_no_flag"
+    wrapper "test_one_empty_file_flag"
+    wrapper "test_multiple_files"
+    wrapper "test_multiple_empty_files_no_flag"
+    wrapper "test_multiple_empty_files_flag"
+    wrapper "test_mixed_files_no_flag"
+    wrapper "test_mixed_files_flag"
+    wrapper "test_with_cp_flags"
+    wrapper "test_with_cp_target_dir"
+    wrapper "test_with_cp_no_target_dir"
+    echo "====================================="
+
+    echo "Summary"
+    echo "Passed: ${NPASSED}"
+    echo "Failed: ${NFAILED}"
+}
+
+main

--- a/tests/test_cpreq.sh
+++ b/tests/test_cpreq.sh
@@ -57,6 +57,7 @@ err_chk() {
 }
 
 err_exit() {
+    export msg="$1"
     /lfs/h1/nco/idsb/noscrub/russell.manser/git_repos/prod_util/tests/patch/err_exit
 }
 
@@ -88,10 +89,6 @@ test_one_empty_file_no_opt() {
     # -------------------------------------------------------
     # Test that cpreq *fails* to copy a single zero size file
     # without the specified '-z' option
-    #
-    # This test will pass upon *any* failure.
-    #
-    # TODO: pass only on specific failure.
     # -------------------------------------------------------
     test_dir=${TMP_DIR}/${FUNCNAME}
     setup "${test_dir}"
@@ -101,7 +98,7 @@ test_one_empty_file_no_opt() {
     touch ${test_dir}/source_dir/file.txt
     $TARGET_SCRIPT ${test_dir}/source_dir/file.txt ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
 
-    err_msg=$( grep "FATAL ERROR" ${test_dir}/${FUNCNAME}.err )
+    err_msg=$( grep "FATAL ERROR: return code 2" ${test_dir}/${FUNCNAME}.err )
 
     test ! -z "$err_msg"
     check_results ${FUNCNAME} $? "$err_msg"
@@ -154,10 +151,6 @@ test_multiple_empty_files_no_opt() {
     # -----------------------------------------------------
     # Test that cpreq *fails* to copy multiple files if one
     # or more are size zero and the '-z' is not specified
-    #
-    # This test will pass upon *any* failure.
-    #
-    # TODO: pass only on specific failure.
     # -----------------------------------------------------
     test_dir=${TMP_DIR}/${FUNCNAME}
     setup "${test_dir}"
@@ -170,7 +163,7 @@ test_multiple_empty_files_no_opt() {
 
     $TARGET_SCRIPT ${test_dir}/source_dir/file* ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
 
-    err_msg=$( grep "FATAL ERROR" ${test_dir}/${FUNCNAME}.err )
+    err_msg=$( grep "FATAL ERROR: return code 2" ${test_dir}/${FUNCNAME}.err )
 
     test ! -z "$err_msg"
     check_results ${FUNCNAME} $? "$err_msg"
@@ -204,10 +197,6 @@ test_mixed_files_no_opt() {
     # ---------------------------------------------------
     # Test that cpreq *fails* to copy multiple files when
     # one or more are size zero and '-z' is not specified
-    #
-    # This test will pass upon *any* failure.
-    #
-    # TODO: pass only on specific failure.
     # ---------------------------------------------------
     test_dir=${TMP_DIR}/${FUNCNAME}
     setup "${test_dir}"
@@ -219,7 +208,7 @@ test_mixed_files_no_opt() {
 
     $TARGET_SCRIPT ${test_dir}/source_dir/file* ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
 
-    err_msg=$( grep "FATAL ERROR" ${test_dir}/${FUNCNAME}.err )
+    err_msg=$( grep "FATAL ERROR: return code 2" ${test_dir}/${FUNCNAME}.err )
 
     test ! -z "$err_msg"
     check_results ${FUNCNAME} $? "$err_msg"
@@ -252,10 +241,6 @@ test_directory_no_opt() {
     # ------------------------------------------------
     # Test that copying a directory with an empty file
     # *fails* without '-z'
-    #
-    # This test will pass upon *any* failure
-    #
-    # TODO: pass only on specific failure
     # ------------------------------------------------
     test_dir=${TMP_DIR}/${FUNCNAME}
     setup "${test_dir}"
@@ -267,7 +252,7 @@ test_directory_no_opt() {
 
     $TARGET_SCRIPT -r ${test_dir}/source_dir/ ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
 
-    err_msg=$( grep -E "FATAL ERROR.*2" ${test_dir}/${FUNCNAME}.err )
+    err_msg=$( grep "FATAL ERROR: return code 2" ${test_dir}/${FUNCNAME}.err )
 
     test ! -z "$err_msg"
     check_results ${FUNCNAME} $? "$err_msg"

--- a/tests/test_cpreq.sh
+++ b/tests/test_cpreq.sh
@@ -12,41 +12,50 @@
 # -----------------
 
 setup() {
-    test_dir=$1
+    func_name=$1
+    test_dir=${TMP_DIR}/${func_name}
     source_dir=${test_dir}/source_dir
     target_dir=${test_dir}/target_dir
     mkdir -p ${source_dir}
     mkdir -p ${target_dir}
+
+    export pgm=${func_name}
+
+    echo "${test_dir}"
 }
 
-teardown() {
-    echo "${FUNCNAME} not implemented"
-    #cd ${TMP_DIR}
-    #rm -rf ${TMP_DIR}/*
-    #cd ${TMP_DIR}/..
-    #rmdir ${TMP_DIR}
-}
 
 wrapper() {
     func=$1
+
+    test_dir=$( setup "$func" )
+    export test_dir
+
+    ${func} "${test_dir}"
     echo "----------------------------"
 
-    ${func}
-
-    echo "----------------------------"
-    echo ""
+    teardown
 }
+
+
+teardown() {
+    unset pgm
+    unset test_dir
+}
+
 
 check_results() {
     func_name=$1
     err=$2
     err_msg=$3
 
+    target_script=$( basename "$0" )
+
     if [[ $err -eq 0 ]]; then
-        echo "PASSED: ${func_name}"
+        echo "PASSED: ${target_script}:${func_name}"
         export NPASSED=$(( NPASSED + 1 ))
     else
-        echo "FAILED: ${func_name}"
+        echo "FAILED: ${target_script}:${func_name}"
         echo "$err_msg"
         export NFAILED=$(( NFAILED + 1))
     fi
@@ -67,13 +76,9 @@ err_exit() {
 
 
 test_one_file() {
+    # -------------------------------------------------
     # Test that cpreq copies a single nonzero size file
     # -------------------------------------------------
-    test_dir=${TMP_DIR}/${FUNCNAME}
-    setup "${test_dir}"
-
-    export pgm=${FUNCNAME}
-
     echo "This is a file with text in it" > ${test_dir}/source_dir/file.txt
 
     $TARGET_SCRIPT ${test_dir}/source_dir/file.txt ${test_dir}/target_dir/ 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
@@ -90,11 +95,6 @@ test_one_empty_file_no_opt() {
     # Test that cpreq *fails* to copy a single zero size file
     # without the specified '-z' option
     # -------------------------------------------------------
-    test_dir=${TMP_DIR}/${FUNCNAME}
-    setup "${test_dir}"
-
-    export pgm=${FUNCNAME}
-
     touch ${test_dir}/source_dir/file.txt
     $TARGET_SCRIPT ${test_dir}/source_dir/file.txt ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
 
@@ -110,11 +110,6 @@ test_one_empty_file_opt() {
     # Test that cpreq copys a single zero size file with the
     # '-z' option specified
     # ------------------------------------------------------
-    test_dir=${TMP_DIR}/${FUNCNAME}
-    setup "${test_dir}"
-
-    export pgm=${FUNCNAME}
-
     touch ${test_dir}/source_dir/file.txt
     $TARGET_SCRIPT -z ${test_dir}/source_dir/file.txt ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
 
@@ -129,11 +124,6 @@ test_multiple_files() {
     # --------------------------------------------------
     # Test that cpreq copies multiple nonzero size files
     # --------------------------------------------------
-    test_dir=${TMP_DIR}/${FUNCNAME}
-    setup "${test_dir}"
-
-    export pgm=${FUNCNAME}
-
     for i in $( seq 1 3 ); do
         echo "This is file $i with text in it" > ${test_dir}/source_dir/file${i}.txt
     done
@@ -152,11 +142,6 @@ test_multiple_empty_files_no_opt() {
     # Test that cpreq *fails* to copy multiple files if one
     # or more are size zero and the '-z' is not specified
     # -----------------------------------------------------
-    test_dir=${TMP_DIR}/${FUNCNAME}
-    setup "${test_dir}"
-
-    export pgm=${FUNCNAME}
-
     for i in $( seq 1 3 ); do
         touch ${test_dir}/source_dir/file${i}.txt
     done
@@ -175,11 +160,6 @@ test_multiple_empty_files_opt() {
     # Test the cpreq copies multiple zero size files with
     # the '-z' option specified
     # ---------------------------------------------------
-    test_dir=${TMP_DIR}/${FUNCNAME}
-    setup "${test_dir}"
-
-    export pgm=${FUNCNAME}
-
     for i in $( seq 1 3 ); do
         touch ${test_dir}/source_dir/file${i}.txt
     done
@@ -198,11 +178,6 @@ test_mixed_files_no_opt() {
     # Test that cpreq *fails* to copy multiple files when
     # one or more are size zero and '-z' is not specified
     # ---------------------------------------------------
-    test_dir=${TMP_DIR}/${FUNCNAME}
-    setup "${test_dir}"
-
-    export pgm=${FUNCNAME}
-
     echo "This is a file with text in it" > ${test_dir}/source_dir/file1.txt
     touch ${test_dir}/source_dir/file2.txt
 
@@ -220,11 +195,6 @@ test_mixed_files_opt() {
     # Test that cpreq copies multiple files when one or
     # more are size zero and '-z' is specified
     # -------------------------------------------------
-    test_dir=${TMP_DIR}/${FUNCNAME}
-    setup "${test_dir}"
-
-    export pgm=${FUNCNAME}
-
     echo "This is a file with text in it" > ${test_dir}/source_dir/file1.txt
     touch ${test_dir}/source_dir/file2.txt
 
@@ -242,11 +212,6 @@ test_directory_no_opt() {
     # Test that copying a directory with an empty file
     # *fails* without '-z'
     # ------------------------------------------------
-    test_dir=${TMP_DIR}/${FUNCNAME}
-    setup "${test_dir}"
-
-    export pgm=${FUNCNAME}
-
     echo "This is a file with text in it" > ${test_dir}/source_dir/file1.txt
     touch ${test_dir}/source_dir/file2.txt
 
@@ -264,11 +229,6 @@ test_directory_opt() {
     # Test copying a directory recursively
     # which contains an empty file with '-z'
     # --------------------------------------
-    test_dir=${TMP_DIR}/${FUNCNAME}
-    setup "${test_dir}"
-
-    export pgm=${FUNCNAME}
-
     echo "This is a file with text in it" > ${test_dir}/source_dir/file1.txt
     touch ${test_dir}/source_dir/file2.txt
 
@@ -285,11 +245,6 @@ test_one_cp_opt() {
     # ----------------------------
     # Test with a single cp option
     # ----------------------------
-    test_dir=${TMP_DIR}/${FUNCNAME}
-    setup "${test_dir}"
-
-    export pgm=${FUNCNAME}
-
     echo "This is a file with text in it" > ${test_dir}/source_dir/file1.txt
 
     $TARGET_SCRIPT -p ${test_dir}/source_dir/file1.txt ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
@@ -305,11 +260,6 @@ test_one_cp_opt_zero_byte() {
     # -----------------------------------
     # Test with -z and a single cp option
     # -----------------------------------
-    test_dir=${TMP_DIR}/${FUNCNAME}
-    setup "${test_dir}"
-
-    export pgm=${FUNCNAME}
-
     touch ${test_dir}/source_dir/file1.txt
 
     $TARGET_SCRIPT -z -p ${test_dir}/source_dir/file1.txt ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
@@ -325,16 +275,11 @@ test_multiple_cp_opts() {
     # ---------------------------------------------
     # Test that cpreq accepts multiple cp arguments
     # ---------------------------------------------
-    test_dir=${TMP_DIR}/${FUNCNAME}
-    setup "${test_dir}"
-
-    export pgm=${FUNCNAME}
-
     echo "This is a file with text in it" > ${test_dir}/source_dir/file1.txt
     
     $TARGET_SCRIPT -z -pr ${test_dir}/source_dir/file* ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
 
-    err_msg=$( egrep "FATAL ERROR|illegal" ${test_dir}/${FUNCNAME}.err )
+    err_msg=$( grep -E "FATAL ERROR|illegal" ${test_dir}/${FUNCNAME}.err )
 
     test -z "$err_msg"
     check_results ${FUNCNAME} $? "$err_msg"
@@ -345,11 +290,6 @@ test_multiple_cp_opts_zero_byte() {
     # --------------------------------------
     # Test with '-z' and multiple cp options
     # --------------------------------------
-    test_dir=${TMP_DIR}/${FUNCNAME}
-    setup "${test_dir}"
-
-    export pgm=${FUNCNAME}
-
     touch ${test_dir}/source_dir/file1.txt ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
 
     err_msg=$( grep "FATAL ERROR" ${test_dir}/${FUNCNAME}.err )
@@ -362,11 +302,6 @@ test_cp_opt_t() {
     # ----------------------
     # Test with cp -t option
     # ----------------------
-    test_dir=${TMP_DIR}/${FUNCNAME}
-    setup "${test_dir}"
-
-    export pgm=${FUNCNAME}
-
     echo "This is a file with text in it" > ${test_dir}/source_dir/file1.txt
 
     $TARGET_SCRIPT -t ${test_dir}/target_dir ${test_dir}/source_dir/file1.txt 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
@@ -386,11 +321,11 @@ main() {
     export -f err_chk
     export -f err_exit
 
-    TMP_ROOT="/lfs/h1/nco/stmp/russell.manser"
+    TMP_ROOT="/lfs/h1/nco/stmp/$( whoami )"
     export TMP_DIR="${TMP_ROOT}/test_cpreq_$(date +%Y%m%d_%H%M_%N)"
     echo "Test directory: ${TMP_DIR}"
 
-    PKG_ROOT="/lfs/h1/nco/idsb/noscrub/russell.manser/git_repos/prod_util"
+    PKG_ROOT=$( pwd )
     export TARGET_SCRIPT=${PKG_ROOT}/ush/cpreq
 
     export NPASSED=0

--- a/tests/test_cpreq.sh
+++ b/tests/test_cpreq.sh
@@ -49,7 +49,7 @@ check_results() {
     err=$2
     err_msg=$3
 
-    target_script=$( basename "$0" )
+    target_script=$( basename "$TARGET_SCRIPT" )
 
     if [[ $err -eq 0 ]]; then
         echo "PASSED: ${target_script}:${func_name}"
@@ -94,14 +94,25 @@ test_one_empty_file_no_opt() {
     # -------------------------------------------------------
     # Test that cpreq *fails* to copy a single zero size file
     # without the specified '-z' option
+    #
+    # Test that 'cp' is successful for the same conditions
     # -------------------------------------------------------
     touch ${test_dir}/source_dir/file.txt
     $TARGET_SCRIPT ${test_dir}/source_dir/file.txt ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
 
     err_msg=$( grep "FATAL ERROR: return code 2" ${test_dir}/${FUNCNAME}.err )
 
-    test ! -z "$err_msg"
-    check_results ${FUNCNAME} $? "$err_msg"
+    if [[ "$TARGET_SCRIPT" =~ cpreq ]]; then
+        test ! -z "$err_msg"
+        err=$?
+    elif [[ "$TARGET_SCRIPT" = "cp" ]]; then
+        test -z "$err_msg"
+        err=$?
+    else
+        echo "$TARGET_SCRIPT is not a valid test option for $FUNCNAME" >&2
+        err=3
+    fi
+    check_results ${FUNCNAME} $err "$err_msg"
 }
 
 
@@ -141,6 +152,8 @@ test_multiple_empty_files_no_opt() {
     # -----------------------------------------------------
     # Test that cpreq *fails* to copy multiple files if one
     # or more are size zero and the '-z' is not specified
+    #
+    # Test that 'cp' is successful for the same conditions
     # -----------------------------------------------------
     for i in $( seq 1 3 ); do
         touch ${test_dir}/source_dir/file${i}.txt
@@ -150,8 +163,18 @@ test_multiple_empty_files_no_opt() {
 
     err_msg=$( grep "FATAL ERROR: return code 2" ${test_dir}/${FUNCNAME}.err )
 
-    test ! -z "$err_msg"
-    check_results ${FUNCNAME} $? "$err_msg"
+    if [[ "$TARGET_SCRIPT" =~ cpreq ]]; then
+        test ! -z "$err_msg"
+        err=$?
+    elif [[ "$TARGET_SCRIPT" = "cp" ]]; then
+        test -z "$err_msg"
+        err=$?
+    else
+        echo "$TARGET_SCRIPT is not a valid test option for $FUNCNAME" >&2
+        err=3
+    fi
+
+    check_results ${FUNCNAME} $err "$err_msg"
 }
 
 
@@ -174,10 +197,12 @@ test_multiple_empty_files_opt() {
 
 
 test_mixed_files_no_opt() {
-    # ---------------------------------------------------
+    # ----------------------------------------------------
     # Test that cpreq *fails* to copy multiple files when
     # one or more are size zero and '-z' is not specified
-    # ---------------------------------------------------
+    #
+    # Test that 'cp' is successful for the same conditions
+    # ----------------------------------------------------
     echo "This is a file with text in it" > ${test_dir}/source_dir/file1.txt
     touch ${test_dir}/source_dir/file2.txt
 
@@ -185,8 +210,18 @@ test_mixed_files_no_opt() {
 
     err_msg=$( grep "FATAL ERROR: return code 2" ${test_dir}/${FUNCNAME}.err )
 
-    test ! -z "$err_msg"
-    check_results ${FUNCNAME} $? "$err_msg"
+    if [[ "$TARGET_SCRIPT" =~ cpreq ]]; then
+        test ! -z "$err_msg"
+        err=$?
+    elif [[ "$TARGET_SCRIPT" = "cp" ]]; then
+        test -z "$err_msg"
+        err=$?
+    else
+        echo "$TARGET_SCRIPT is not a valid test option for $FUNCNAME" >&2
+        err=3
+    fi
+
+    check_results ${FUNCNAME} $err "$err_msg"
 }
 
 
@@ -208,10 +243,12 @@ test_mixed_files_opt() {
 
 
 test_directory_no_opt() {
-    # ------------------------------------------------
+    # ----------------------------------------------------
     # Test that copying a directory with an empty file
     # *fails* without '-z'
-    # ------------------------------------------------
+    #
+    # Test that 'cp' is successful for the same conditions
+    # ----------------------------------------------------
     echo "This is a file with text in it" > ${test_dir}/source_dir/file1.txt
     touch ${test_dir}/source_dir/file2.txt
 
@@ -219,8 +256,18 @@ test_directory_no_opt() {
 
     err_msg=$( grep "FATAL ERROR: return code 2" ${test_dir}/${FUNCNAME}.err )
 
-    test ! -z "$err_msg"
-    check_results ${FUNCNAME} $? "$err_msg"
+    if [[ "$TARGET_SCRIPT" =~ cpreq ]]; then
+        test ! -z "$err_msg"
+        err=$?
+    elif [[ "$TARGET_SCRIPT" = "cp" ]]; then
+        test -z "$err_msg"
+        err=$?
+    else
+        echo "$TARGET_SCRIPT is not a valid test option for $FUNCNAME" >&2
+        err=3
+    fi
+
+    check_results ${FUNCNAME} $err "$err_msg"
 }
 
 
@@ -331,6 +378,7 @@ main() {
     export NPASSED=0
     export NFAILED=0
 
+    echo "====================================="
     echo "$( basename "$0" )"
     echo "====================================="
     wrapper "test_one_file"
@@ -347,6 +395,18 @@ main() {
     wrapper "test_one_cp_opt_zero_byte"
     wrapper "test_multiple_cp_opts"
     wrapper "test_multiple_cp_opts_zero_byte"
+    wrapper "test_cp_opt_t"
+
+    export TARGET_SCRIPT="cp"
+
+    wrapper "test_one_file"
+    wrapper "test_one_empty_file_no_opt"
+    wrapper "test_multiple_files"
+    wrapper "test_multiple_empty_files_no_opt"
+    wrapper "test_mixed_files_no_opt"
+    wrapper "test_directory_no_opt"
+    wrapper "test_one_cp_opt"
+    wrapper "test_multiple_cp_opts"
     wrapper "test_cp_opt_t"
     echo "====================================="
 

--- a/tests/test_cpreq.sh
+++ b/tests/test_cpreq.sh
@@ -359,6 +359,35 @@ test_cp_opt_t() {
     check_results ${FUNCNAME} $? "$err_msg"
 }
 
+test_cp_opt_long_form() {
+    # ---------------------------
+    # Test with long form options
+    # ---------------------------
+    echo "This is a file with text in it" > ${test_dir}/source_dir/file1.txt
+
+    $TARGET_SCRIPT --preserve=ownership --no-clobber ${test_dir}/source_dir/file1.txt ${test_dir}/target_dir/ 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
+
+    err_msg=$( grep "FATAL ERROR" ${test_dir}/${FUNCNAME}.err )
+
+    test -z "$err_msg"
+    check_results ${FUNCNAME} $? "$err_msg"
+}
+
+test_cp_opt_long_form_zero_byte() {
+    # ------------------------------------
+    # Test with '-z' and long form options
+    # ------------------------------------
+    echo "This is a file with test in it" > ${test_dir}/source_dir/file1.txt
+    touch ${test_dir}/source_dir/file2.txt
+
+    $TARGET_SCRIPT -z --preserve=ownership --no-clobber ${test_dir}/source_dir/file* ${test_dir}/target_dir/ 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
+
+    err_msg=$( grep "FATAL ERROR" ${test_dir}/${FUNCNAME}.err )
+
+    test -z "$err_msg"
+    check_results ${FUNCNAME} $? "$err_msg"
+}
+
 
 # -----------
 # Main script
@@ -396,6 +425,8 @@ main() {
     wrapper "test_multiple_cp_opts"
     wrapper "test_multiple_cp_opts_zero_byte"
     wrapper "test_cp_opt_t"
+    wrapper "test_cp_opt_long_form"
+    wrapper "test_cp_opt_long_form_zero_byte"
 
     export TARGET_SCRIPT="cp"
 
@@ -408,6 +439,7 @@ main() {
     wrapper "test_one_cp_opt"
     wrapper "test_multiple_cp_opts"
     wrapper "test_cp_opt_t"
+    wrapper "test_cp_opt_long_form"
     echo "====================================="
 
     echo "Summary"

--- a/tests/test_cpreq.sh
+++ b/tests/test_cpreq.sh
@@ -248,6 +248,54 @@ test_mixed_files_opt() {
 }
 
 
+test_directory_no_opt() {
+    # ------------------------------------------------
+    # Test that copying a directory with an empty file
+    # *fails* without '-z'
+    #
+    # This test will pass upon *any* failure
+    #
+    # TODO: pass only on specific failure
+    # ------------------------------------------------
+    test_dir=${TMP_DIR}/${FUNCNAME}
+    setup "${test_dir}"
+
+    export pgm=${FUNCNAME}
+
+    echo "This is a file with text in it" > ${test_dir}/source_dir/file1.txt
+    touch ${test_dir}/source_dir/file2.txt
+
+    $TARGET_SCRIPT -r ${test_dir}/source_dir/ ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
+
+    err_msg=$( grep -E "FATAL ERROR.*2" ${test_dir}/${FUNCNAME}.err )
+
+    test ! -z "$err_msg"
+    check_results ${FUNCNAME} $? "$err_msg"
+}
+
+
+test_directory_opt() {
+    # --------------------------------------
+    # Test copying a directory recursively
+    # which contains an empty file with '-z'
+    # --------------------------------------
+    test_dir=${TMP_DIR}/${FUNCNAME}
+    setup "${test_dir}"
+
+    export pgm=${FUNCNAME}
+
+    echo "This is a file with text in it" > ${test_dir}/source_dir/file1.txt
+    touch ${test_dir}/source_dir/file2.txt
+
+    $TARGET_SCRIPT -z -r ${test_dir}/source_dir/ ${test_dir}/target_dir 1> ${test_dir}/${FUNCNAME}.out 2> ${test_dir}/${FUNCNAME}.err
+
+    err_msg=$( grep "FATAL ERROR" ${test_dir}/${FUNCNAME}.err )
+
+    test -z "$err_msg"
+    check_results ${FUNCNAME} $? "$err_msg"
+}
+
+
 test_one_cp_opt() {
     # ----------------------------
     # Test with a single cp option
@@ -373,6 +421,8 @@ main() {
     wrapper "test_multiple_empty_files_opt"
     wrapper "test_mixed_files_no_opt"
     wrapper "test_mixed_files_opt"
+    wrapper "test_directory_no_opt"
+    wrapper "test_directory_opt"
     wrapper "test_one_cp_opt"
     wrapper "test_one_cp_opt_zero_byte"
     wrapper "test_multiple_cp_opts"

--- a/ush/cpreq
+++ b/ush/cpreq
@@ -10,7 +10,8 @@
 # zero to be copied.
 #
 # Error codes:
-#   1 : one or more input files do not exist or have size zero
+#   1 : command failed on `cp`
+#   2 : one or more files have size zero and '-z' was not specified
 #
 
 if [[ $# -lt 2 ]]; then
@@ -53,15 +54,9 @@ else
   targets=("${cp_args[@]:0:$n_targets}")
 fi
 
-if [[ "$zero_byte" == "FALSE" ]]; then
-  for targ in "${targets[@]}"; do
-    if [[ ! -s $targ ]]; then
-      echo "$0: file does not exist or has size zero $targ" >&2
-        err=1
-    fi
-  done
-  export err=${err:-0};
-  err_chk "One or more input files do not exist or have size 0"
+zero_byte_files=$( find "${targets[@]}" -size 0 -print )
+if [[ "$zero_byte" != "TRUE" ]] && [[ -n "$zero_byte_files" ]]; then
+    export err=2; err_chk "One or more input files have size zero: ${zero_byte_files[*]}"
 fi
 
 cmd="cp ${cp_opts[*]} ${cp_args[*]}"

--- a/ush/cpreq
+++ b/ush/cpreq
@@ -19,11 +19,22 @@ if [[ $# -lt 2 ]]; then
 fi
 
 cp_args=()
+cp_opts=()
 zero_byte="FALSE"
 while [[ $# -gt 0 ]]; do
   case $1 in
     -z)
       zero_byte="TRUE"
+      shift
+      ;;
+    # 'cp -t' reverses source/directory arguments
+    # so it needs special handling
+    -t)
+      cp_args+=("$1")
+      shift
+      ;;
+    -*)
+      cp_opts+=("$1")
       shift
       ;;
     *)
@@ -33,8 +44,14 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-n_targets=$(( ${#cp_args[@]} - 1 ))
-targets=("${cp_args[@]:0:$n_targets}")
+# Handle 'cp -t' case
+if [[ "${cp_args[*]}" =~ [[:space:]]?-t[[:space:]] ]]; then
+  targets=("${cp_args[@]#*-t}")
+  targets=("${targets[@]:1}")
+else
+  n_targets=$(( ${#cp_args[@]} - 1 ))
+  targets=("${cp_args[@]:0:$n_targets}")
+fi
 
 if [[ "$zero_byte" == "FALSE" ]]; then
   for targ in "${targets[@]}"; do
@@ -47,5 +64,6 @@ if [[ "$zero_byte" == "FALSE" ]]; then
   err_chk "One or more input files do not exist or have size 0"
 fi
 
-cp "${cp_args[@]}"
-export err=$?; err_chk "'cp " "${cp_args[@]}" "' was not successful."
+cmd="cp ${cp_opts[*]} ${cp_args[*]}"
+$cmd
+export err=$?; err_chk "'$cmd' was not successful."

--- a/ush/cpreq
+++ b/ush/cpreq
@@ -1,6 +1,51 @@
-#!/bin/sh
+#!/bin/bash
+#
+# cpreq
+# 
+# Purpose: copy one or more files which are required for an
+# application to run. The files must have size > 0.
+#
+# cpreq behaves similar to cp and accepts all valid cp options.
+# It accepts an additional option -z that allows files with size
+# zero to be copied.
+#
+# Error codes:
+#   1 : one or more input files do not exist or have size zero
+#
 
-cp $*
-if [ $? -ne 0 ] ; then
-  err_exit "'cp $*' was not successful."
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $( basename "$0" ) [-z] [OPTION] SOURCE [...] DEST"
+  exit 1
 fi
+
+cp_args=()
+zero_byte="FALSE"
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -z)
+      zero_byte="TRUE"
+      shift
+      ;;
+    *)
+      cp_args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+n_targets=$(( ${#cp_args[@]} - 1 ))
+targets=("${cp_args[@]:0:$n_targets}")
+
+if [[ "$zero_byte" == "FALSE" ]]; then
+  for targ in "${targets[@]}"; do
+    if [[ ! -s $targ ]]; then
+      echo "$0: file does not exist or has size zero $targ" >&2
+        err=1
+    fi
+  done
+  export err=${err:-0};
+  err_chk "One or more input files do not exist or have size 0"
+fi
+
+cp "${cp_args[@]}"
+export err=$?; err_chk "'cp " "${cp_args[@]}" "' was not successful."


### PR DESCRIPTION
- [x] Closes #6 

### Summary
This PR adds a check for 0-byte files in `cpreq` and an option to skip the 0-byte check. By default `cpreq` will now raise an error when one or more of its arguments are size 0.

### Notes
- This PR also adds: a) a full test suite for `cpreq` that covers many use cases and b) patched versions of `err_exit` and `err_chk` designed specifically for use in tests.
- The `tests` directory is not allowed under the current implementation standards. I believe it should be included here to demonstrate that the current solution works and to make testing easier in the future. See https://github.com/NCO-HPC/nws-hpc-standards/issues/17 for further discussion.

### Todo
- [ ] Assess and document which production packages expect to copy 0-byte files under normal conditions

### Complete
- [x] Remove hard-coded paths from `tests/test_cpreq.sh`
- [x] Implement or remove `teardown` function in `test/test_cpreq.sh`
- [x] Specify failure conditions for test cases which are expected to fail
- [x] Add modifications to handle `-t` and `-T` options for `cp`
- [x] Fix bug for single-options `cp` cases
- [x] Add tests for long-form options
- [x] Test against packages on WCOSS
- [x] Test replacing `cpreq` with `cp` against packages on WCOSS
- [x] Test in para for 1 week (started on 11/07/2025 ~1644Z)