### PR TITLE
Use PBS_JOBNAME in mail.py to determine if a job is remote or local

### DIFF
--- a/ush/mail.py
+++ b/ush/mail.py
@@ -56,7 +56,7 @@ def send(subject, message_body, to_address=default_recipient, cc_address=None, b
     ecFlow_task_path = getenv('ECF_NAME')
     if ecFlow_task_path:
         job_info.append(("ecFlow Task", ecFlow_task_path))
-    if getenv('ECF_RID'):
+    if getenv('PBS_JOBNAME'):
         try:
             stdout_file = check_output("qstat -fwx {0} | grep Output_Path".format(getenv('ECF_RID')), shell=True).decode().split(":")[1]
         except:


### PR DESCRIPTION
- [x] Closes #8 

This PR changes the environment variable used to check if a PBS job was submitted in `ush/mail.py`. See the linked issue for details.

Test scripts can be found on Dogwood at:
- `/lfs/h1/ops/test/packages/test_prod_util/ecf/test_mail_pbs.ecf`
- `/lfs/h1/ops/test/packages/test_prod_util/ecf/test_mail_local.ecf`
- `/lfs/h1/ops/test/packages/test_prod_util/jobs/TEST_MAIL`

And output files for successful runs can be found at:
- **Dogwood**: `/lfs/h1/ops/test/output/20251106/test_mail_pbs.o77585638`
- **decflow02**: `/tfs/ops/para/output/ecflow//test/primary/00/test_prod_util/test_mail_local.7`