### PR TITLE
Add error checking and hardening to err_chk and err_exit

### DIFF
--- a/test/test_err_exit.sh
+++ b/test/test_err_exit.sh
@@ -140,7 +140,7 @@ test_sendecf_yes() {
     local output
     output=$($SCRIPT_UNDER_TEST 2>&1)
     
-    if [[ "$output" == *"mock_timeout 30 mock_ecflow_client --msg mock_ecf_job: Job failed"* ]] && \
+    if [[ "$output" == *"mock_timeout 30 mock_ecflow_client --msg mock_ecf_job: Job UNKNOWN failed"* ]] && \
        [[ "$output" == *"mock_timeout 30 mock_ssh my-ecflow-host echo"* ]] && \
        [[ "$output" == *">> $ECF_JOBOUT"* ]]; then
         pass "$FUNCNAME"
@@ -153,6 +153,9 @@ test_sendecf_yes() {
 test_kill_via_ecflow_when_no_pbs() {
     setup
     # PBS_JOBID is unset
+
+    export SENDECF="YES"
+
     local output
     output=$($SCRIPT_UNDER_TEST 2>&1)
     

--- a/test/test_err_exit.sh
+++ b/test/test_err_exit.sh
@@ -27,7 +27,7 @@ setup() {
     export TEST_TEMP_DIR="$(mktemp -d)"
     
     # Unset all potential environment variables to ensure a clean state
-    unset jobid pgm err DATA pgmout SENDECF ECF_HOST ECF_JOBOUT PBS_JOBID
+    unset jobid pgm err DATA pgmout SENDECF ECF_HOST ECF_JOBOUT PBS_JOBID ECF_NAME JOBID KILLJOB
     
     # Provide a default ECF_NAME so the script doesn't abort early on ${ECF_NAME:?}
     export ECF_NAME="mock_ecf_job"
@@ -150,6 +150,53 @@ test_sendecf_yes() {
     teardown
 }
 
+test_ecflow_log_no_ecf_jobout() {
+    setup
+    export SENDECF="YES"
+    export ECF_JOBOUT="/path/to/ecf.out"
+
+    local output
+    output=$($SCRIPT_UNDER_TEST 2>&1)
+
+    if [[ "$output" == *"FATAL ERROR Unable to write to ecflow server as either ECF_HOST or ECF_JOBOUT are undefined!!"* ]]; then
+        pass "$FUNCNAME"
+    else
+        fail "$FUNCNAME" "ecFlow log written when ECF_HOST is empty. Output: $output"
+    fi
+    teardown
+}
+
+test_ecflow_log_no_ecf_host() {
+    setup
+    export SENDECF="YES"
+    export ECF_HOST="my-ecflow-host"
+
+    local output
+    output=$($SCRIPT_UNDER_TEST 2>&1)
+
+    if [[ "$output" == *"FATAL ERROR Unable to write to ecflow server as either ECF_HOST or ECF_JOBOUT are undefined!!"* ]]; then
+        pass "$FUNCNAME"
+    else
+        fail "$FUNCNAME" "ecFlow log written when ECF_JOBOUT is empty. Output: $output"
+    fi
+    teardown
+}
+
+test_ecflow_log_no_ecf_jobout_no_ecf_host() {
+    setup
+    export SENDECF="YES"
+
+    local output
+    output=$($SCRIPT_UNDER_TEST 2>&1)
+
+    if [[ "$output" == *"FATAL ERROR Unable to write to ecflow server as either ECF_HOST or ECF_JOBOUT are undefined!!"* ]]; then
+        pass "$FUNCNAME"
+    else
+        fail "$FUNCNAME" "ecFlow log written when ECF_HOST and ECF_JOBOUT are empty. Output: $output"
+    fi
+    teardown
+}
+
 test_kill_via_ecflow_when_no_pbs() {
     setup
     # PBS_JOBID is unset
@@ -167,6 +214,26 @@ test_kill_via_ecflow_when_no_pbs() {
     teardown
 }
 
+test_kill_via_ecflow_no_ecf_name() {
+    setup
+
+    export SENDECF="YES"
+    export ECF_HOST="my-ecflow-host"
+    export ECF_JOBOUT="/path/to/ecf.out"
+    export ECF_NAME=""
+    export JOBID="12345.scheduler"
+
+    local output
+    output=$($SCRIPT_UNDER_TEST 2>&1)
+
+    if [[ "$output" == *"FATAL ERROR Unable to kill ecflow job as ECF_NAME variable is not set!!"* ]]; then
+        pass "$FUNCNAME"
+    else
+        fail "$FUNCNAME" "Expected qdel call missing or JOBID not set properly. Output: $output"
+    fi
+    teardown
+}
+
 test_kill_via_qdel_when_pbs_set() {
     setup
     export PBS_JOBID="12345.scheduler"
@@ -178,6 +245,22 @@ test_kill_via_qdel_when_pbs_set() {
         pass "$FUNCNAME"
     else
         fail "$FUNCNAME" "Expected qdel call missing or ecflow called improperly. Output: $output"
+    fi
+    teardown
+}
+
+test_kill_via_qdel_no_pbs_jobid() {
+    setup
+
+    local output
+    output=$($SCRIPT_UNDER_TEST 2>&1)
+
+    if [[ "$output" == *"Could not find a scheduler command or job ID to kill the current job"* ]] && \
+        [[ "$output" == *"KILLJOB = qdel"* ]] && \
+        echo "$output" | grep -qE "^JOBID   = $" ; then
+        pass "$FUNCNAME"
+    else
+        fail "$FUNCNAME" "Expected failure did not occur when JOBID is empty. Output: $output"
     fi
     teardown
 }
@@ -199,8 +282,13 @@ test_data_warning_when_unset
 test_ls_when_data_set
 test_errfile_appends_to_pgmout
 test_sendecf_yes
+test_ecflow_log_no_ecf_jobout
+test_ecflow_log_no_ecf_host
+test_ecflow_log_no_ecf_jobout_no_ecf_host
 test_kill_via_ecflow_when_no_pbs
+test_kill_via_ecflow_no_ecf_name
 test_kill_via_qdel_when_pbs_set
+test_kill_via_qdel_no_pbs_jobid
 
 echo "-------------------------------------------------------------"
 echo "Test Run Complete: $PASSED passed, $FAILED failed."

--- a/ush/err_chk
+++ b/ush/err_chk
@@ -35,9 +35,9 @@ if [ "${err}" -eq 139 ]; then
             >&2 echo "  \$DATA variable not set. Cannot copy core files!"
         else
             if ! cd "${DATA}"; then
-				>&2 echo "  Cannot cd to DATA directory ${DATA}. Cannot copy core files!"
-				err_exit $@
-			fi
+                >&2 echo "  Cannot cd to DATA directory ${DATA}. Cannot copy core files!"
+                err_exit $@
+            fi
             if [ -s core ]; then
                 mkdir -p "${COREROOT}"
                 cp -p core "${COREROOT}/${pgm}.$$.core"

--- a/ush/err_chk
+++ b/ush/err_chk
@@ -4,34 +4,55 @@
 #
 # ABSTRACT:  This script checks a return code in $err.  If $err=0
 # a message that the program completed is put in the job outputfile and
-# in a log file.  If $err != 0 then fail messages are put in job 
+# in a log file.  If $err != 0 then fail messages are put in job
 # output file and the job is terminated.
-# 
+#
 # USAGE:  To use this script one must export the following variables
 # to the script:  err, pgm, pgmout, jobid
 
-if [ -z "$err" ]; then err_exit "RETURN CODE NOT EXPORTED prior to running err_chk" ; exit ; fi
-if [ $err -eq 0 ]; then echo "$pgm completed cleanly" ; exit ; fi
+err=${err:-""}           # Return code from program
+pgm=${pgm:-""}           # Program name
+COREROOT=${COREROOT:-""} # Directory to copy core files to
+DATA=${DATA:-""}         # Working directory
+
+if [ -z "${err}" ]; then
+    err_exit "RETURN CODE NOT EXPORTED prior to running err_chk"
+    exit
+fi
+if [ ${err} -eq 0 ]; then
+    echo "${pgm} completed cleanly"
+    exit
+fi
 
 #  If error return code is 139, then program segfaulted.
 #  Look for any core files, and save them to a directory in /ptmp
-if [ $err -eq 139 ]; then
-  if [ -z "$COREROOT" ]; then
-    >&2 echo "SegFault reported but \$COREROOT variable not set. Will not copy files."
-  else
-    >&2 echo "SegFault reported. Copying core files to ${COREROOT}"
-    cd $DATA
-    if [ -s core ]; then
-      mkdir -p ${COREROOT}
-      cp -p core ${COREROOT}/$pgm.$$.core
-    elif [ -s core.* ]; then
-      mkdir -p ${COREROOT}
-      cp -p core.* ${COREROOT}/
-    fi 
-    for coredir in `ls -d coredir.*`; do
-      mkdir -p ${COREROOT}/$coredir
-      cp -p ${coredir}/* ${COREROOT}/${coredir}/
-    done
-  fi
+if [ ${err} -eq 139 ]; then
+    if [ -z "${COREROOT}" ]; then
+        >&2 echo "SegFault reported but \$COREROOT variable not set. Will not copy files."
+    else
+        >&2 echo "SegFault reported. Copying core files to ${COREROOT}"
+        if [ -z "${DATA}" ]; then
+            >&2 echo "  \$DATA variable not set. Cannot copy core files!"
+        else
+            cd "${DATA}"
+            if [ -s core ]; then
+                mkdir -p "${COREROOT}"
+                cp -p core "${COREROOT}/${pgm}.$$.core"
+            else
+                core_list=$(find . -maxdepth 1 -type f -name "core.*")
+                for core_file in ${core_list}; do
+                    if [ -s "${core_file}" ]; then
+                        mkdir -p "${COREROOT}"
+                        cp -p "${core_file}" "${COREROOT}/"
+                    fi
+                done
+            fi
+            coredirs=$(find . -maxdepth 1 -type d -name "coredir.*")
+            for coredir in ${coredirs}; do
+                mkdir -p "${COREROOT}/${coredir}"
+                cp -p "${coredir}"/* "${COREROOT}/${coredir}/"
+            done
+        fi
+    fi
 fi
 err_exit $@

--- a/ush/err_chk
+++ b/ush/err_chk
@@ -19,14 +19,14 @@ if [ -z "${err}" ]; then
     err_exit "RETURN CODE NOT EXPORTED prior to running err_chk"
     exit
 fi
-if [ ${err} -eq 0 ]; then
+if [ "${err}" -eq 0 ]; then
     echo "${pgm} completed cleanly"
     exit
 fi
 
 #  If error return code is 139, then program segfaulted.
 #  Look for any core files, and save them to a directory in /ptmp
-if [ ${err} -eq 139 ]; then
+if [ "${err}" -eq 139 ]; then
     if [ -z "${COREROOT}" ]; then
         >&2 echo "SegFault reported but \$COREROOT variable not set. Will not copy files."
     else
@@ -34,7 +34,10 @@ if [ ${err} -eq 139 ]; then
         if [ -z "${DATA}" ]; then
             >&2 echo "  \$DATA variable not set. Cannot copy core files!"
         else
-            cd "${DATA}"
+            if ! cd "${DATA}"; then
+				>&2 echo "  Cannot cd to DATA directory ${DATA}. Cannot copy core files!"
+				err_exit $@
+			fi
             if [ -s core ]; then
                 mkdir -p "${COREROOT}"
                 cp -p core "${COREROOT}/${pgm}.$$.core"

--- a/ush/err_exit
+++ b/ush/err_exit
@@ -13,7 +13,6 @@ err=${err:-""}             # Return code from program
 pgm=${pgm:-""}             # Program name
 pgmout=${pgmout:-""}       # Program output file
 jobid=${jobid:-"UNKNOWN"}  # Job ID
-COREROOT=${COREROOT:-""}   # Directory to copy core files to
 DATA=${DATA:-""}           # Working directory
 SENDECF=${SENDECF:-"NO"}   # Send message to ecflow
 ECF_NAME=${ECF_NAME:-""}   # Name of the ECF Job

--- a/ush/err_exit
+++ b/ush/err_exit
@@ -76,16 +76,14 @@ fi
 
 # KILL THE JOB VIA ECFLOW:
 if [[ "${SENDECF}" == "YES" ]]; then
-    if [[ -n "${ECF_NAME}" ]]; then
+    if [[ -z "${ECF_NAME}" ]]; then
         echo "FATAL ERROR Unable to kill ecflow job as ECF_NAME variable is not set!!"
     else
         echo "Killing the job via ecflow kill"
         ecflow_client --kill="${ECF_NAME}"
     fi
-fi
-
 # KILL THE JOB VIA JOB SCHEDULER COMMAND:
-if [[ -n "${KILLJOB}" && -n "${JOBID}" ]]; then
+elif [[ -n "${KILLJOB}" && -n "${JOBID}" ]]; then
     echo "Killing the job via ${KILLJOB}"
     ${KILLJOB} ${JOBID}
 else

--- a/ush/err_exit
+++ b/ush/err_exit
@@ -18,8 +18,8 @@ SENDECF=${SENDECF:-"NO"}   # Send message to ecflow
 ECF_NAME=${ECF_NAME:-""}   # Name of the ECF Job
 ECF_HOST=${ECF_HOST:-""}   # ecflow hostname
 ECF_JOBOUT=${ECF_JOBOUT:-""} # ecflow job output file
-JOBID=${JOBID:-""}         # Scheduler Job ID e.g. $PBS_JOBID, $SLURM_ID, etc
-KILLJOB=${KILLJOB:-""}     # Scheduler command to kill a job e.g. qdel, scancel, etc
+JOBID=${JOBID:-$PBS_JOBID}   # Scheduler Job ID e.g. $PBS_JOBID, $SLURM_ID, etc
+KILLJOB=${KILLJOB:-qdel}     # Scheduler command to kill a job e.g. qdel, scancel, etc
 
 msg1=${*:-Job ${jobid} failed}
 if [[ -n "${pgm}" ]]; then

--- a/ush/err_exit
+++ b/ush/err_exit
@@ -17,9 +17,10 @@ COREROOT=${COREROOT:-""}   # Directory to copy core files to
 DATA=${DATA:-""}           # Working directory
 SENDECF=${SENDECF:-"NO"}   # Send message to ecflow
 ECF_NAME=${ECF_NAME:-""}   # Name of the ECF Job
-PBS_JOBID=${PBS_JOBID:-""} # PBS Job ID
 ECF_HOST=${ECF_HOST:-""}   # ecflow hostname
 ECF_JOBOUT=${ECF_JOBOUT:-""} # ecflow job output file
+JOBID=${JOBID:-""}         # Scheduler Job ID e.g. $PBS_JOBID, $SLURM_ID, etc
+KILLJOB=${KILLJOB:-""}     # Scheduler command to kill a job e.g. qdel, scancel, etc
 
 msg1=${*:-Job ${jobid} failed}
 if [[ -n "${pgm}" ]]; then
@@ -73,17 +74,22 @@ if [[ "${SENDECF}" == "YES" ]]; then
     fi
 fi
 
-# KILL THE JOB:
+# KILL THE JOB VIA ECFLOW:
 if [[ "${SENDECF}" == "YES" ]]; then
     if [[ -n "${ECF_NAME}" ]]; then
         echo "FATAL ERROR Unable to kill ecflow job as ECF_NAME variable is not set!!"
     else
+        echo "Killing the job via ecflow kill"
         ecflow_client --kill="${ECF_NAME}"
     fi
 fi
 
-if [[ -n "${PBS_JOBID}" ]]; then
-    qdel "${PBS_JOBID}"
-elif [[ -n "${SLURM_JOB_ID}" ]]; then
-    scancel "${SLURM_JOB_ID}"
+# KILL THE JOB VIA JOB SCHEDULER COMMAND:
+if [[ -n "${KILLJOB}" && -n "${JOBID}" ]]; then
+    echo "Killing the job via ${KILLJOB}"
+    ${KILLJOB} ${JOBID}
+else
+    echo "Could not find a scheduler command or job ID to kill the current job"
+    echo "KILLJOB = ${KILLJOB}"
+    echo "JOBID   = ${JOBID}"
 fi

--- a/ush/err_exit
+++ b/ush/err_exit
@@ -9,57 +9,75 @@
 # script: jobid, SENDECF, pgm, pgmout, DATA. One can provide
 # a message for the logfile by passing it to the script as an argument.
 
-msg1=${@:-Job $jobid failed}
-if [ -n "$pgm" ]; then
-  msg1+=", ERROR IN $pgm"
+err=${err:-""}             # Return code from program
+pgm=${pgm:-""}             # Program name
+pgmout=${pgmout:-""}       # Program output file
+jobid=${jobid:-"UNKNOWN"}  # Job ID
+COREROOT=${COREROOT:-""}   # Directory to copy core files to
+DATA=${DATA:-""}           # Working directory
+SENDECF=${SENDECF:-"NO"}   # Send message to ecflow
+ECF_NAME=${ECF_NAME:-""}    # Name of the ECF Job
+PBS_JOBID=${PBS_JOBID:-""} # PBS Job ID
+
+msg1=${@:-Job ${jobid} failed}
+if [[ -n "${pgm}" ]]; then
+    msg1+=", ERROR IN ${pgm}"
 fi
-if [ -n "$err" ]; then
-  msg1+=" RETURN CODE $err"
+if [[ -n "${err}" ]]; then
+    msg1+=" RETURN CODE ${err}"
 fi
 
 msg2="
 -------------------------------------------------------------
--- FATAL ERROR: $msg1
--- ABNORMAL EXIT at $(date) on $HOSTNAME
+-- FATAL ERROR: ${msg1}
+-- ABNORMAL EXIT at $(date) on ${HOSTNAME}
 -------------------------------------------------------------
 "
 
->&2 echo "$msg2"
+>&2 echo "${msg2}"
 
 # list loaded modules
 module list
 >&2 echo ""
 
->&2 echo "$msg1"
+>&2 echo "${msg1}"
 
 # list files in temporary working directory
-if [ -n "$DATA" ]; then
-  >&2 echo $DATA
-  >&2 ls -ltr $DATA
+if [[ -n "${DATA}" ]]; then
+    >&2 echo "${DATA}"
+    >&2 ls -ltr "${DATA}"
 else
-  >&2 echo "WARNING: DATA variable not defined"
+    >&2 echo "WARNING: DATA variable not defined"
 fi
 
 # save standard output
-if [ -n "$pgmout" ]; then
-  if [ -s errfile ]; then
-    echo "----- contents of errfile -----" >> $pgmout
-    cat errfile >> $pgmout
-  fi
-  >&2 cat $pgmout
-elif [ -s errfile ]; then
-  >&2 cat errfile
+if [[ -n "${pgmout}" ]]; then
+    if [[ -s errfile ]]; then
+        echo "----- contents of errfile -----" >> "${pgmout}"
+        cat errfile >> "${pgmout}"
+    fi
+    >&2 cat "${pgmout}"
+elif [[ -s errfile ]]; then
+    >&2 cat errfile
 fi
 
 # Write to ecflow log:
-if [ "$SENDECF" = "YES" ]; then
-  timeout 30 ecflow_client --msg "$ECF_NAME: $msg1"
-  timeout 30 ssh $ECF_HOST "echo \"$msg2\" >> ${ECF_JOBOUT:?}"
+if [[ "${SENDECF}" == "YES" ]]; then
+    timeout 30 ecflow_client --msg "${ECF_NAME}: ${msg1}"
+    timeout 30 ssh "${ECF_HOST}" "echo \"${msg2}\" >> ${ECF_JOBOUT:?}"
 fi
 
 # KILL THE JOB:
-if [ -z $PBS_JOBID ]; then
-ecflow_client --kill=${ECF_NAME:?}
-else
-qdel $PBS_JOBID
+if [[ "${SENDECF}" == "YES" ]]; then
+    if [[ -n "${ECF_NAME}" ]]; then
+        echo "FATAL ERROR Unable to kill ecflow job as ECF_NAME variable is not set!!"
+    else
+        ecflow_client --kill="${ECF_NAME}"
+    fi
+fi
+
+if [[ -n "${PBS_JOBID}" ]]; then
+    qdel "${PBS_JOBID}"
+elif [[ -n "${SLURM_JOB_ID}" ]]; then
+    scancel "${SLURM_JOB_ID}"
 fi

--- a/ush/err_exit
+++ b/ush/err_exit
@@ -16,10 +16,12 @@ jobid=${jobid:-"UNKNOWN"}  # Job ID
 COREROOT=${COREROOT:-""}   # Directory to copy core files to
 DATA=${DATA:-""}           # Working directory
 SENDECF=${SENDECF:-"NO"}   # Send message to ecflow
-ECF_NAME=${ECF_NAME:-""}    # Name of the ECF Job
+ECF_NAME=${ECF_NAME:-""}   # Name of the ECF Job
 PBS_JOBID=${PBS_JOBID:-""} # PBS Job ID
+ECF_HOST=${ECF_HOST:-""}   # ecflow hostname
+ECF_JOBOUT=${ECF_JOBOUT:-""} # ecflow job output file
 
-msg1=${@:-Job ${jobid} failed}
+msg1=${*:-Job ${jobid} failed}
 if [[ -n "${pgm}" ]]; then
     msg1+=", ERROR IN ${pgm}"
 fi
@@ -64,7 +66,11 @@ fi
 # Write to ecflow log:
 if [[ "${SENDECF}" == "YES" ]]; then
     timeout 30 ecflow_client --msg "${ECF_NAME}: ${msg1}"
-    timeout 30 ssh "${ECF_HOST}" "echo \"${msg2}\" >> ${ECF_JOBOUT:?}"
+    if [[ -z "${ECF_JOBOUT}" || "${ECF_HOST}" == "" ]]; then
+        echo "FATAL ERROR Unable to write to ecflow server as either ECF_HOST or ECF_JOBOUT are undefined!!"
+    else
+        timeout 30 ssh "${ECF_HOST}" "echo \"${msg2}\" >> ${ECF_JOBOUT}"
+    fi
 fi
 
 # KILL THE JOB:


### PR DESCRIPTION
This adds several script-hardening features to the `err_chk` and `err_exit` scripts:

1. Check for undefined variables needed by either script
2. Correct the use of `-s`, which does not work on globs
3. Use best practices for variable references
    - Use `${}` around all variables
    - Use double quotes around variables to prevent accidental splitting
    - Remove `:?` and replace with checks for variable existence
4. Convert `! -z` to `-n`, which is equivalent but easier to interpret
5. For `err_exit` (a bash script), use bash conditional blocks (i.e. `[[ <boolean> ]]`)
6. Add additional error handling (e.g. check that `DATA` can be `cd`'d to)
7. Establish standard spacing
    - Tabs converted to spaces
    - All indentations are now increments of 4

Resolves #11 