### PR TITLE
Call ecflow_client only when scheduler unavailable

### DIFF
--- a/test/test_err_exit.sh
+++ b/test/test_err_exit.sh
@@ -249,6 +249,26 @@ test_kill_via_qdel_when_pbs_set() {
     teardown
 }
 
+test_kill_via_qdel_when_pbs_set_and_sendecf_yes() {
+    # Check that ecflow_client --kill never gets called for a job
+    # submitted with PBS.
+    # Refs: #17
+
+    setup
+    export PBS_JOBID="12345.scheduler"
+    export SENDECF="YES"
+
+    local output
+    output=$($SCRIPT_UNDER_TEST 2>&1)
+
+    if [[ "$output" == *"mock_ecflow_client --kill"* ]]; then
+        fail "$FUNCNAME" "ecflow_client --kill called improperly. Output: $output"
+    else
+        pass "$FUNCNAME"
+    fi
+    teardown
+}
+
 test_kill_via_qdel_no_pbs_jobid() {
     setup
 
@@ -289,6 +309,7 @@ test_ecflow_log_no_ecf_jobout_no_ecf_host
 test_kill_via_ecflow_when_no_pbs
 test_kill_via_ecflow_no_ecf_name
 test_kill_via_qdel_when_pbs_set
+test_kill_via_qdel_when_pbs_set_and_sendecf_yes
 test_kill_via_qdel_no_pbs_jobid
 
 echo "-------------------------------------------------------------"

--- a/test/test_err_exit.sh
+++ b/test/test_err_exit.sh
@@ -221,7 +221,7 @@ test_kill_via_ecflow_no_ecf_name() {
     export ECF_HOST="my-ecflow-host"
     export ECF_JOBOUT="/path/to/ecf.out"
     export ECF_NAME=""
-    export JOBID="12345.scheduler"
+    export KILLJOB=""
 
     local output
     output=$($SCRIPT_UNDER_TEST 2>&1)
@@ -229,7 +229,7 @@ test_kill_via_ecflow_no_ecf_name() {
     if [[ "$output" == *"FATAL ERROR Unable to kill ecflow job as ECF_NAME variable is not set!!"* ]]; then
         pass "$FUNCNAME"
     else
-        fail "$FUNCNAME" "Expected qdel call missing or JOBID not set properly. Output: $output"
+        fail "$FUNCNAME" "Expected error for missing ECF_NAME was not raised. Output: $output"
     fi
     teardown
 }
@@ -255,7 +255,8 @@ test_kill_via_qdel_no_pbs_jobid() {
     local output
     output=$($SCRIPT_UNDER_TEST 2>&1)
 
-    if [[ "$output" == *"Could not find a scheduler command or job ID to kill the current job"* ]] && \
+    if [[ "$output" == *"Could not find an appropriate command to kill the current job"* ]] && \
+        [[ "$output" == *"SENDECF = NO"* ]] && \
         [[ "$output" == *"KILLJOB = qdel"* ]] && \
         echo "$output" | grep -qE "^JOBID   = $" ; then
         pass "$FUNCNAME"

--- a/ush/err_exit
+++ b/ush/err_exit
@@ -8,6 +8,12 @@
 # USAGE:  To use this script one must export the following variables to the
 # script: jobid, SENDECF, pgm, pgmout, DATA. One can provide
 # a message for the logfile by passing it to the script as an argument.
+#
+# NOTES: err_exit must only call qdel OR ecflow_client --kill, not both.
+# - If using PBS     --> kill the job with qdel
+# - If NOT using PBS --> kill the job with ecflow_client --kill
+# Calling ecflow_client --kill on a PBS job will NOT kill the job immediately
+# Refs: #17
 
 err=${err:-""}             # Return code from program
 pgm=${pgm:-""}             # Program name

--- a/ush/err_exit
+++ b/ush/err_exit
@@ -73,20 +73,21 @@ if [[ "${SENDECF}" == "YES" ]]; then
     fi
 fi
 
+# KILL THE JOB VIA JOB SCHEDULER COMMAND:
+if [[ -n "${KILLJOB}" && -n "${JOBID}" ]]; then
+    echo "Killing the job via ${KILLJOB}"
+    ${KILLJOB} ${JOBID}
 # KILL THE JOB VIA ECFLOW:
-if [[ "${SENDECF}" == "YES" ]]; then
+elif [[ "${SENDECF}" == "YES" ]]; then
     if [[ -z "${ECF_NAME}" ]]; then
         echo "FATAL ERROR Unable to kill ecflow job as ECF_NAME variable is not set!!"
     else
         echo "Killing the job via ecflow kill"
         ecflow_client --kill="${ECF_NAME}"
     fi
-# KILL THE JOB VIA JOB SCHEDULER COMMAND:
-elif [[ -n "${KILLJOB}" && -n "${JOBID}" ]]; then
-    echo "Killing the job via ${KILLJOB}"
-    ${KILLJOB} ${JOBID}
 else
-    echo "Could not find a scheduler command or job ID to kill the current job"
+    echo "Could not find an appropriate command to kill the current job"
+    echo "SENDECF = ${SENDECF}"
     echo "KILLJOB = ${KILLJOB}"
     echo "JOBID   = ${JOBID}"
 fi


### PR DESCRIPTION
This pull request restores the original behavior of err_exit. If a scheduler command *is* available, err_exit will use that command to kill the job. *Otherwise*, ecflow_client --kill will be called.

Outputs from test jobs can be found on cdecflow02 in this parent directory: `/lfs/h1/nco/idsb/noscrub/russell.manser/projects/gfs_v17/`.

Tests were run with [this ecf script](https://gist.github.com/RussellManser-NCO/785ac62e8134c3836f1083c71fa60681).

**Tests with changes from #13**
* SENDECF=YES
  * ❌ Output: `ecflow/submit/test/ecflow_training_test.out.buggy_sendecf_yes` - continued execution after `export err=1; err_chk`
  * ❌ ecFlow output: `ecflow/test/t1.19` - contains output from `killecfjob` (unexpected)
* SENDECF=NO
  * ✅ Output: `ecflow/submit/test/ecflow_training_test.out.buggy_sendecf_no` - called `qdel` and stopped execution immediately
  * ✅ ecFlow output: `ecflow/test/t1.22` - only contains output from `head.h`

**Tests with bugfix provided in this PR**
* SENDECF=YES
  * ✅ Output: `ecflow/submit/test/ecflow_training_test.out.buggy_sendecf_yes` - called `qdel` and stopped execution immediately
  * ✅ ecFlow output: `ecflow/test/t1.25` - only contains output from `head.h`
* SENDECF=NO
  * ✅ Output: `ecflow/submit/test/ecflow_training_test.out.fixed_sendecf_no` - called `qdel` and stopped execution immediately
  * ✅ ecFlow output: `ecflow/test/t1.26` - only contains output from `head.h`

Refs: #17, #13
Closes: #17